### PR TITLE
reload-workers: behave correctly with differently-formatted hosts

### DIFF
--- a/reload-workers.sh
+++ b/reload-workers.sh
@@ -8,7 +8,7 @@ cat /etc/hosts | \
     # :TRICKY: order citus hosts alphabetically, in hopes similar entries are
     # grouped together. This makes the hostnames in worker list predictable.
     sort -k 1,1 -k 2,2 | sort -k 1,1 -u | \
-    cut -f2 | \
+    awk -v N=2 '{print $N}' | \
     xargs -I host echo "host 5432" > "$PGDATA/pg_worker_list.conf"
 
 if [ "$CITUS_STANDALONE" ]


### PR DESCRIPTION
In my config, hosts was basically
127.0.0.1   localhost other garbage

The `cut` was splitting on tab, meaning 'localhost other garbage' was
left in. Use awk to split on all whitespace.
